### PR TITLE
NS-Toolbox-1 Add clone() functionality to Modelish.

### DIFF
--- a/Modelish/README.md
+++ b/Modelish/README.md
@@ -26,7 +26,7 @@ Note that
 - the name is the same for both setter and getter.
 - the overall code to implement this is quite small!
 
-### Usage
+## Usage
 
 
 ```java
@@ -39,4 +39,24 @@ Note that
 ```
 
 After the lock() call the model cannot be modified. There is intentionally no unlock.
+
+## Clone and modify model
+
+```java
+
+    public interface TestModel extends CloneableModelishModel<TestModel> {
+    
+        String name();
+        TestModel name(String name);
+    
+        int age();
+        TestModel age(int age);
+    
+        String address();
+        TestModel address(String address);
+    
+    }
+```
+
+With this model `_clone()` can be called to get a current clone of model that will be open for changes until _lock() is called.
 

--- a/Modelish/pom.xml
+++ b/Modelish/pom.xml
@@ -5,26 +5,11 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>Modelish</artifactId>
-    <version>1.1.0</version>
-
-<!--    <properties>-->
-<!--        <maven.compiler.source>11</maven.compiler.source>-->
-<!--        <maven.compiler.target>11</maven.compiler.target>-->
-<!--    </properties>-->
-
-    <!--
-    <dependencies>
-        <dependency>
-            <groupId>se.natusoft.tools</groupId>
-            <artifactId>ns-toolbox-apis</artifactId>
-            <version>1.1.0</version>
-        </dependency>
-    </dependencies>
-    -->
+    <version>1.1.1</version>
 
 </project>

--- a/Modelish/src/main/java/se/natusoft/tools/modelish/CloneableModelishModel.java
+++ b/Modelish/src/main/java/se/natusoft/tools/modelish/CloneableModelishModel.java
@@ -1,5 +1,5 @@
-/*
- *
+/* 
+ * 
  * PROJECT
  *     Name
  *         Modelish
@@ -29,19 +29,19 @@
  *     tommy ()
  *         Changes:
  *         2022-02-12: Created!
- *
+ *         
  */
 package se.natusoft.tools.modelish;
 
-public interface TestModel extends CloneableModelishModel<TestModel> {
+/**
+ * Let your models extend this interface instead of ModelishModel directly to be able to clone them.
+ *
+ * @param <T>
+ */
+public interface CloneableModelishModel<T> extends ModelishModel<T> {
 
-    String name();
-    TestModel name(String name);
-
-    int age();
-    TestModel age(int age);
-
-    String address();
-    TestModel address(String address);
-
+    /**
+     * @return A clone of current model. New model will not be locked.
+     */
+    T _clone();
 }

--- a/Modelish/src/main/java/se/natusoft/tools/modelish/ModelishModel.java
+++ b/Modelish/src/main/java/se/natusoft/tools/modelish/ModelishModel.java
@@ -48,5 +48,5 @@ public interface ModelishModel<T> {
      *
      * @return itself.
      */
-    T lock();
+    T _lock();
 }

--- a/Modelish/src/test/java/se/natusoft/tools/modelish/ModelishTest.java
+++ b/Modelish/src/test/java/se/natusoft/tools/modelish/ModelishTest.java
@@ -38,13 +38,13 @@ import org.junit.jupiter.api.Test;
 public class ModelishTest {
 
     @Test
-    public void testModelish() {
+    public void verifyModelishNormalUsage() {
 
         TestModel testModel = Modelish.create( TestModel.class )
                 .name("Tommy Svensson")
                 .age(53)
                 .address("Stockholm")
-                .lock();
+                ._lock();
 
         assert testModel.name().equals( "Tommy Svensson" );
         assert testModel.age() == 53;
@@ -58,5 +58,33 @@ public class ModelishTest {
         catch ( IllegalArgumentException iae ) {
             assert iae.getMessage().equals( "Update of read only object not allowed!" );
         }
+    }
+
+    @Test
+    public void verifyCloningModel() {
+
+        TestModel testModel = Modelish.create( TestModel.class )
+                .name("Tommy Svensson")
+                .age(53)
+                .address("Stockholm")
+                ._lock();
+
+        // Note that new model is not locked even if old one was.
+        TestModel clonedModel = testModel._clone().address("Liljeholmen")._lock();
+
+        // Make sure the original hasn't changed.
+        assert testModel.address().equals( "Stockholm" );
+
+        // The cloned should have the updated value.
+        assert clonedModel.address().equals( "Liljeholmen" );
+
+        // Make sure clone is locked.
+        try {
+            clonedModel.name("Tommy B Svensson");
+        }
+        catch ( IllegalArgumentException iae ) {
+            assert iae.getMessage().equals( "Update of read only object not allowed!" );
+        }
+
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Restructured and split into many jars, one for APIs and one for each tool.
 
 ### 1.1.0
 
-- Added [Modelish](Modelish/), a fluent data model defined as interface and instantiated using the Modelish class.
+Added [Modelish](Modelish/), a fluent data model defined as interface and instantiated using the Modelish class.
 
+### 1.1.1
 
+Modelish now supports cloning a model, modify it, and then lock the clone. For this `CloneableModelishModel` must be extended by the model API interface. 

--- a/RPNQuery/pom.xml
+++ b/RPNQuery/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>RPNQuery</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <dependencies>
         <dependency>

--- a/filtering-service-loader/pom.xml
+++ b/filtering-service-loader/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>filtering-service-loader</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
 <!--    <properties>-->
 <!--        <maven.compiler.source>11</maven.compiler.source>-->

--- a/ns-toolbox-apis/pom.xml
+++ b/ns-toolbox-apis/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ns-toolbox-apis</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
 <!--    <properties>-->
 <!--        <maven.compiler.source>17</maven.compiler.source>-->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>se.natusoft.tools</groupId>
     <artifactId>ns-toolbox</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <url>https://github/tombensve/NS-Toolbox</url>
 


### PR DESCRIPTION
Adds `_clone()` API to clone and modify a model instance. Can of course be locked when updates have been made.