### PR TITLE
NS-Toolbox-4 Cloning currently does not work on non primitive fields.

### DIFF
--- a/Modelish/README.md
+++ b/Modelish/README.md
@@ -30,15 +30,17 @@ Note that
 
 
 ```java
-    TestModel testModel = Modelish.create( TestModel.class )
+    TestModel userInfo = Modelish.create( TestModel.class )
             .name("Tommy Svensson")
             .age(53)
             .address("Stockholm")
-            .lock();
+            ._lock();
 
 ```
 
-After the lock() call the model cannot be modified. There is intentionally no unlock.
+After the lock() call the model cannot be modified. There is intentionally no unlock. 
+
+Note that for complex models with submodels there is now also an `recursiveLock()` method that locks model and any submodels.
 
 ## Clone and modify model
 

--- a/Modelish/pom.xml
+++ b/Modelish/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.1</version>
+        <version>1.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>Modelish</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 
 </project>

--- a/Modelish/src/main/java/se/natusoft/tools/modelish/CloneableModelishModel.java
+++ b/Modelish/src/main/java/se/natusoft/tools/modelish/CloneableModelishModel.java
@@ -1,35 +1,35 @@
-/* 
- * 
+/*
+ *
  * PROJECT
  *     Name
  *         Modelish
- *     
+ *
  *     Description
  *         Provides a RPN Query against name value set of data (Properties, Map).
- *         
+ *
  * COPYRIGHTS
  *     Copyright (C) 2022 by Natusoft AB All rights reserved.
- *     
+ *
  * LICENSE
  *     Apache 2.0 (Open Source)
- *     
+ *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
- *     
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,
  *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
- *     
+ *
  * AUTHORS
  *     tommy ()
  *         Changes:
  *         2022-02-12: Created!
- *         
+ *
  */
 package se.natusoft.tools.modelish;
 
@@ -41,7 +41,8 @@ package se.natusoft.tools.modelish;
 public interface CloneableModelishModel<T> extends ModelishModel<T> {
 
     /**
-     * @return A clone of current model. New model will not be locked.
+     * @return A clone of current model. New model will not be locked, and neither will sub models!!
+     *         You have to lock clone and all its sub models manually if/when you want them locked.
      */
     T _clone();
 }

--- a/Modelish/src/test/java/se/natusoft/tools/modelish/User.java
+++ b/Modelish/src/test/java/se/natusoft/tools/modelish/User.java
@@ -28,32 +28,20 @@
  * AUTHORS
  *     tommy ()
  *         Changes:
- *         2022-02-11: Created!
+ *         2022-02-12: Created!
  *
  */
 package se.natusoft.tools.modelish;
 
-/**
- * Base interface for modelish models.
- *
- * @param <T>
- */
-public interface ModelishModel<T> {
+public interface User extends CloneableModelishModel<User> {
 
-    /**
-     * This has to be called when all values have been set to make it impossible to modify
-     * the objects content. A locked model cannot be unlocked.
-     *
-     * This is not required, but is a good idea to call this!
-     *
-     * @return self.
-     */
-    T _lock();
+    String id();
+    User id( String id);
 
-    /**
-     * Does the same as lock() but also recursively on sub models of model.
-     *
-     * @return self.
-     */
-    T _recursiveLock();
+    int loginCount();
+    User loginCount(int count);
+
+    UserInfo userInfo();
+    User userInfo(UserInfo userInfo);
+
 }

--- a/Modelish/src/test/java/se/natusoft/tools/modelish/UserInfo.java
+++ b/Modelish/src/test/java/se/natusoft/tools/modelish/UserInfo.java
@@ -3,28 +3,28 @@
  * PROJECT
  *     Name
  *         Modelish
- *     
+ *
  *     Description
  *         Provides a RPN Query against name value set of data (Properties, Map).
- *         
+ *
  * COPYRIGHTS
  *     Copyright (C) 2022 by Natusoft AB All rights reserved.
- *     
+ *
  * LICENSE
  *     Apache 2.0 (Open Source)
- *     
+ *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
- *     
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,
  *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
- *     
+ *
  * AUTHORS
  *     tommy ()
  *         Changes:
@@ -33,15 +33,15 @@
  */
 package se.natusoft.tools.modelish;
 
-public interface TestModel extends CloneableModelishModel<TestModel> {
+public interface UserInfo extends CloneableModelishModel<UserInfo> {
 
     String name();
-    TestModel name(String name);
+    UserInfo name( String name);
 
     int age();
-    TestModel age(int age);
+    UserInfo age( int age);
 
     String address();
-    TestModel address(String address);
+    UserInfo address( String address);
 
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Added [Modelish](Modelish/), a fluent data model defined as interface and instan
 ### 1.1.1
 
 Modelish now supports cloning a model, modify it, and then lock the clone. For this `CloneableModelishModel` must be extended by the model API interface. 
+
+### 1.2.1
+
+Modelish now supports recursive cloning of a model that have Modelish models as members. In this case all Modelish models are cloned. 
+
+Since `_lock()` only locks the model `_lock()` was called on and not any Modelish submodel there is now also a `_recursiveLock()` method that locks everything for complex models.

--- a/RPNQuery/pom.xml
+++ b/RPNQuery/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.1</version>
+        <version>1.2.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>RPNQuery</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 
     <dependencies>
         <dependency>

--- a/filtering-service-loader/pom.xml
+++ b/filtering-service-loader/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.1</version>
+        <version>1.2.1</version>
     </parent>
 
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>filtering-service-loader</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 
 <!--    <properties>-->
 <!--        <maven.compiler.source>11</maven.compiler.source>-->

--- a/ns-toolbox-apis/pom.xml
+++ b/ns-toolbox-apis/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>ns-toolbox</artifactId>
         <groupId>se.natusoft.tools</groupId>
-        <version>1.1.1</version>
+        <version>1.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ns-toolbox-apis</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 
 <!--    <properties>-->
 <!--        <maven.compiler.source>17</maven.compiler.source>-->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>se.natusoft.tools</groupId>
     <artifactId>ns-toolbox</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 
     <url>https://github/tombensve/NS-Toolbox</url>
 


### PR DESCRIPTION
Modelish models can now have values that are other Modelish models, and can now also be recursively locked using new "_recusriveLock()".