### PR TITLE
NS-Toolbox-47 Add value validators for models.

### DIFF
--- a/Modelish/README.md
+++ b/Modelish/README.md
@@ -15,6 +15,30 @@ a HashMap.
 
 ## Latest Version
 
+### 3.2.0
+
+Validators are no longer internal even though 3 are provided by default:
+
+- NoNullValidator
+- NotEmptyValidator
+- ValidRangeValidator
+
+The new  interface ModelishValidator defines the "Validator" API. Such can be implemented and
+then added to `ModelValidator.VALIDATORS`. This is a LinkedList of `ModelishValidator` implementations.
+
+So if you have a model made with Modelish and wan't to validate it for something, write an implementation
+and then add an instance of that implementation to `ModelValidator.VALIDATORS`. It is a static 
+`LinkedList` containing 3 validators by default.
+
+If you look at the 3 existing validators you can see that those identify annotations to check data
+for by name, not type! This makes it more flexible. 
+
+Do note that this static `LinkedList` is modifiable, which is why you can add validators to it.
+But this also allows you to remove validators from it! This includes the default ones. I would
+not recommend doing that, but it is possible!
+
+This just offers for easy own runtime validation of own models
+
 ### 3.1.0
 
 New annotations:

--- a/Modelish/pom.xml
+++ b/Modelish/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>Modelish</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 
     <properties>
         <byte-code>11</byte-code>

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/Modelish.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/Modelish.groovy
@@ -34,6 +34,7 @@
 package se.natusoft.tools.modelish
 
 import groovy.transform.CompileStatic
+import se.natusoft.tools.modelish.annotations.validations.NoNull
 import se.natusoft.tools.modelish.internal.Internal
 import se.natusoft.tools.modelish.internal.ModelishInvocationHandler
 

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/ModelishValidator.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/ModelishValidator.groovy
@@ -1,0 +1,43 @@
+package se.natusoft.tools.modelish
+
+import se.natusoft.tools.modelish.validators.NoNullValidator
+import se.natusoft.tools.modelish.validators.NotEmptyValidator
+import se.natusoft.tools.modelish.validators.ValidRangeValidator
+
+import java.lang.annotation.Annotation
+
+/**
+ * Implementations of this can be passed to Modelish.
+ */
+interface ModelishValidator {
+
+    /**
+     * This sets upp default validators, but it is possible to implement and add
+     * any more validators you want! It of course must be done before Modelish is used!
+     *
+     * I provide no API for this, but this is a public LinkedList so you can remove
+     * specific validators if you want! I would however caution against it for
+     * obvious reasons! If you want to turn validations on or off, provide that
+     * functionality in the validator!
+     */
+    static final List<ModelishValidator> VALIDATORS =
+            new LinkedList<ModelishValidator> (
+                    // Default validators! Other validators can be added to this list.
+                    [
+                            new NoNullValidator (),
+                            new NotEmptyValidator (),
+                            new ValidRangeValidator ()
+                    ]
+            )
+
+    /**
+     * Validates a model value.
+     *
+     * @param ann a possible validation annotation to check.
+     * @param args The arguments to validate.
+     * @param methodName The name of the method called.
+     *
+     * @throws ModelishException if not valid.
+     */
+    void validate ( Annotation ann, Object[] args, String methodName ) throws ModelishException
+}

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/NoNull.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/NoNull.groovy
@@ -29,22 +29,13 @@
  *     tommy
  *
  */
-package se.natusoft.tools.modelish
+package se.natusoft.tools.modelish.annotations.validations
 
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
-/**
- * This defines a minimum and maximum value range of a numeric property.
- *
- * The double will be cast to int, long, and float for such values.
- */
 @Retention( RetentionPolicy.RUNTIME)
 @Target( ElementType.METHOD)
-@interface ValidRange {
-
-    double min()
-    double max()
-}
+@interface NoNull {}

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/NotEmpty.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/NotEmpty.groovy
@@ -1,4 +1,4 @@
-package se.natusoft.tools.modelish
+package se.natusoft.tools.modelish.annotations.validations
 
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/ValidRange.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/annotations/validations/ValidRange.groovy
@@ -29,13 +29,22 @@
  *     tommy
  *
  */
-package se.natusoft.tools.modelish
+package se.natusoft.tools.modelish.annotations.validations
 
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
+/**
+ * This defines a minimum and maximum value range of a numeric property.
+ *
+ * The double will be cast to int, long, and float for such values.
+ */
 @Retention( RetentionPolicy.RUNTIME)
 @Target( ElementType.METHOD)
-@interface NoNull {}
+@interface ValidRange {
+
+    double min()
+    double max()
+}

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/NoNullValidator.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/NoNullValidator.groovy
@@ -1,0 +1,32 @@
+package se.natusoft.tools.modelish.validators
+
+import se.natusoft.tools.modelish.ModelishException
+import se.natusoft.tools.modelish.ModelishValidator
+
+import java.lang.annotation.Annotation
+
+/**
+ * Validates that model value is not null.
+ */
+class NoNullValidator implements ModelishValidator {
+
+    /**
+     * Validates a model value.
+     *
+     * @param ann a possible validation annotation to check.
+     * @param args The arguments to validate.
+     * @param methodName The name of the method being called.
+     *
+     * @throws ModelishException if not valid.
+     */
+    @Override
+    void validate ( Annotation ann, Object[] args, String methodName ) throws IllegalArgumentException {
+        String name = ann.toString ().toLowerCase ()
+
+        // NOTE: This does not care about annotation type, only that the name contains "no" and "null"!
+        if ( name.contains ( "no" ) && name.contains ( "null" ) ) {
+            if ( args [ 0 ] == null )
+                throw new IllegalArgumentException ( "null passed to non nullable '${methodName}'!" )
+        }
+    }
+}

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/NotEmptyValidator.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/NotEmptyValidator.groovy
@@ -1,0 +1,32 @@
+package se.natusoft.tools.modelish.validators
+
+import se.natusoft.tools.modelish.ModelishException
+import se.natusoft.tools.modelish.ModelishValidator
+
+import java.lang.annotation.Annotation
+
+class NotEmptyValidator implements ModelishValidator {
+
+    /**
+     * Validates a model value.
+     *
+     * @param ann a possible validation annotation to check.
+     * @param args The arguments to validate.
+     * @param methodName The name of the method called.
+     *
+     * @throws ModelishException if not valid.
+     */
+    @Override
+    void validate ( Annotation ann, Object[] args, String methodName ) throws ModelishException {
+
+        String annName = ann.toString ().toLowerCase ()
+
+        if ( annName.contains ( "no" ) &&
+                annName.contains ( "empty" ) &&
+                args [ 0 ] instanceof String &&
+                ( args [ 0 ] as String ).trim ().size () == 0 ) {
+
+            throw new ModelishException ( "Empty string not allowed here! '(${methodName})'" )
+        }
+    }
+}

--- a/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/ValidRangeValidator.groovy
+++ b/Modelish/src/main/groovy/se/natusoft/tools/modelish/validators/ValidRangeValidator.groovy
@@ -1,0 +1,40 @@
+package se.natusoft.tools.modelish.validators
+
+import se.natusoft.tools.modelish.ModelishException
+import se.natusoft.tools.modelish.ModelishValidator
+import se.natusoft.tools.modelish.annotations.validations.ValidRange
+
+import java.lang.annotation.Annotation
+
+/**
+ * Validates the range of numeric values, excluding BigDecimal!
+ */
+class ValidRangeValidator implements ModelishValidator {
+
+    /**
+     * Validates a range of value.
+     *
+     * @param ann a possible validation annotation to check.
+     * @param args The arguments to validate.
+     * @param methodName The name of the method called.
+     *
+     * @throws se.natusoft.tools.modelish.ModelishException if not valid.
+     */
+    @Override
+    void validate ( Annotation ann, Object[] args, String methodName ) throws ModelishException {
+
+        //
+        String annName = ann.toString ().toLowerCase ()
+
+        if ( annName.contains ( "valid" ) && annName.contains ( "range" ) ) {
+
+            ValidRange validRange = ann as ValidRange
+
+            double value = args [ 0 ] as double
+            if ( value < validRange.min () || value > validRange.max () )
+                throw new ModelishException ( "Value out of range! [${validRange.min ()} - ${validRange.max ()}]" )
+        }
+
+    }
+
+}

--- a/Modelish/src/test/groovy/se/natusoft/tools/modelish/ModelishTest.groovy
+++ b/Modelish/src/test/groovy/se/natusoft/tools/modelish/ModelishTest.groovy
@@ -33,10 +33,12 @@
  */
 package se.natusoft.tools.modelish
 
-import com.sun.org.apache.xpath.internal.operations.Mod
+
 import groovy.transform.CompileStatic
 import org.junit.jupiter.api.Test
-
+import se.natusoft.tools.modelish.annotations.validations.NoNull
+import se.natusoft.tools.modelish.annotations.validations.NotEmpty
+import se.natusoft.tools.modelish.annotations.validations.ValidRange
 
 /**
  * This doubles as test and example of usage.
@@ -538,7 +540,11 @@ class ModelishTest {
 
     interface ValidNumericRange extends Model<ValidNumericRange> {
 
-        @ValidRange(min = -32.0d, max = 200.0d)
+        // Internally these are double values for simplicity, but it is possible
+        // to coerce them into int values as below. Runtime the actual range values
+        // will still be doubles. But that doesn't matter! If that is a Java or a
+        // Groovy feature I don't know.
+        @ValidRange(min = -32, max = 200)
         ValidNumericRange setIntValue(int value)
         int getIntValue()
 


### PR DESCRIPTION
- Added validation of model values based on annotations. The current validation providers check name of annotation to determine it should act on it. So the provided annotations are not forced, but any other annotations used have to have certain words in name to match. Names are converted to lowercase before matching to allow more naming flexibility.